### PR TITLE
refactor(github-action): update goreleaser-action to version v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           install-only: true
+          version: '~> v2'
       - name: Show GoReleaser version
         run: goreleaser -v
 


### PR DESCRIPTION
Lock down the goreleaser-action version in GitHub Actions workflow to ensure reproducibility and stability of releases by specifying version `~> v2`.

closes #7

